### PR TITLE
Clinical data: give numeric values as BigDecimals

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/clinical/PatientIdAnnotatedDataRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/clinical/PatientIdAnnotatedDataRow.groovy
@@ -1,8 +1,10 @@
 package org.transmartproject.db.dataquery.clinical
 
+import groovy.transform.ToString
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.clinical.ClinicalVariableColumn
 
+@ToString(includes = ['patientId', 'data'])
 class PatientIdAnnotatedDataRow implements DataRow<ClinicalVariableColumn, Object> {
 
     Long patientId
@@ -17,17 +19,17 @@ class PatientIdAnnotatedDataRow implements DataRow<ClinicalVariableColumn, Objec
     }
 
     @Override
-    String getAt(int index) {
+    Object getAt(int index) {
         data[index]
     }
 
     @Override
-    String getAt(ClinicalVariableColumn column) {
+    Object getAt(ClinicalVariableColumn column) {
         data[columnToIndex[column]]
     }
 
     @Override
-    Iterator<String> iterator() {
+    Iterator<Object> iterator() {
         data.iterator()
     }
 }

--- a/src/groovy/org/transmartproject/db/dataquery/clinical/PatientRowImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/clinical/PatientRowImpl.groovy
@@ -1,10 +1,12 @@
 package org.transmartproject.db.dataquery.clinical
 
+import groovy.transform.ToString
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.Patient
 import org.transmartproject.core.dataquery.clinical.ClinicalVariableColumn
 import org.transmartproject.core.dataquery.clinical.PatientRow
 
+@ToString(includes = ['label', 'delegatingDataRow'])
 class PatientRowImpl implements PatientRow {
 
     Patient patient

--- a/src/groovy/org/transmartproject/db/dataquery/clinical/TerminalConceptVariablesTabularResult.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/clinical/TerminalConceptVariablesTabularResult.groovy
@@ -81,7 +81,7 @@ class TerminalConceptVariablesTabularResult extends
     private PatientIdAnnotatedDataRow finalizePatientGroup(List<Object[]> list) {
         Map<Integer, TerminalConceptVariable> indexToColumn = localIndexMap.inverse()
 
-        String[] transformedData = new String[localIndexMap.size()]
+        Object[] transformedData = new Object[localIndexMap.size()]
 
         /* don't take Object[] otherwise would be vararg func and
          * further unwrapping needed */

--- a/src/groovy/org/transmartproject/db/dataquery/clinical/variables/TerminalConceptVariable.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/clinical/variables/TerminalConceptVariable.groovy
@@ -21,13 +21,13 @@ class TerminalConceptVariable implements ClinicalVariableColumn {
     String conceptCode,
            conceptPath
 
-    String getVariableValue(Object[] row) {
+    Object getVariableValue(Object[] row) {
         String valueType = row[VALUE_TYPE_COLUMN_INDEX]
 
         if (valueType == TEXT_VALUE_TYPE) {
             row[TEXT_VALUE_COLUMN_INDEX]
         } else {
-            row[NUMBER_VALUE_COLUMN_INDEX] as String
+            row[NUMBER_VALUE_COLUMN_INDEX]
         }
     }
 

--- a/test/integration/org/transmartproject/db/dataquery/clinical/ClinicalDataRetrievalTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/clinical/ClinicalDataRetrievalTests.groovy
@@ -167,14 +167,25 @@ class ClinicalDataRetrievalTests {
 
         assertThat rows, contains(
                 /* see test data */
-                contains(allOf(
-                        isA(String),
-                        startsWith('-45.42') /* may have more zeros */
-                )),
+                contains(isA(Number) /* -45.42 */),
                 contains(equalTo('')),
                 contains(nullValue()))
     }
 
+    @Test
+    void testNumericDataIsInNumericForm() {
+        results = clinicalDataResourceService.retrieveData(testData.queryResult,
+                [ new TerminalConceptVariable(conceptCode: 'c3') ])
+        List<PatientRow> rows = Lists.newArrayList results
+
+        assertThat rows, hasItem(allOf(
+                /* see test data */
+                hasProperty('patient',
+                        hasSameInterfaceProperties(Patient,
+                                testData.patients[2] /* -103 */, ['assays'])),
+                /* numberValue prop in ObservationFact has scale 5 */
+                contains(equalTo(-45.42000 /* big decimal */))))
+    }
 
 
     @Test


### PR DESCRIPTION
This avoids unnecessary conversions from BigDecimal to String and then
to BigDecimal again when those values need to be processed as numbers
(for instance, for binning).
