### PR TITLE
SAN-208 Better handle scaling on x axis

### DIFF
--- a/src/groovy/org/transmartproject/db/ontology/AbstractI2b2Metadata.groovy
+++ b/src/groovy/org/transmartproject/db/ontology/AbstractI2b2Metadata.groovy
@@ -115,6 +115,14 @@ abstract class AbstractI2b2Metadata extends AbstractQuerySpecifyingType
                 equalUnits: slurper.UnitValues?.EqualUnits?.toString(),
         ]
 
+        def seriesMeta = slurper.SeriesMeta
+        if (seriesMeta) {
+            ret.seriesMeta = [
+                    "unit": seriesMeta.Unit?.toString(),
+                    "value": seriesMeta.Value?.toString(),
+                    "label": seriesMeta.DisplayName?.toString(),
+            ]
+        }
         ret
     }
 

--- a/test/unit/org/transmartproject/db/ontology/AbstractI2b2MetadataTests.groovy
+++ b/test/unit/org/transmartproject/db/ontology/AbstractI2b2MetadataTests.groovy
@@ -25,12 +25,16 @@ class AbstractI2b2MetadataTests {
 
         assertThat testee.metadata, allOf(
                 hasEntry('okToUseValues', false),
+
                 hasEntry(equalTo('unitValues'), allOf(
                         hasEntry('normalUnits', 'mg/dl'),
-                        hasEntry('equalUnits', 'mg/dl'),
-                ))
-        )
+                        hasEntry('equalUnits', 'mg/dl'))),
 
+                hasEntry(equalTo('seriesMeta'), allOf(
+                        hasEntry('value', '1'),
+                        hasEntry('unit', 'days'),
+                        hasEntry('label', 'Day 1'))),
+            )
     }
 
     private static final String METADATA_XML = '''<?xml version="1.0"?>
@@ -111,6 +115,11 @@ class AbstractI2b2MetadataTests {
     <Counts/>
     <New/>
   </Analysis>
+  <SeriesMeta>
+      <Value>1</Value>
+      <Unit>days</Unit>
+      <DisplayName>Day 1</DisplayName>
+   </SeriesMeta>
 </ValueMetadata>
 '''
 }


### PR DESCRIPTION
-metadata now returns a map with keys 'unit', 'value' and 'label' regarding unit scaling information
