### PR TITLE
Issues/uat 71 add uniprot name to annotations

### DIFF
--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/protein/DeProteinAnnotation.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/protein/DeProteinAnnotation.groovy
@@ -29,6 +29,7 @@ class DeProteinAnnotation {
     static constraints = {
         peptide     maxSize:  800
         uniprotId   nullable: true, maxSize: 200
+        uniprotName nullable: true, maxSize: 200
 
         //biomarkerId nullable: true, maxSize: 400
         //organism    nullable: true, maxSize: 800

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/protein/DeProteinAnnotation.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/protein/DeProteinAnnotation.groovy
@@ -6,6 +6,7 @@ class DeProteinAnnotation {
 
     String   peptide
     String   uniprotId
+    String   uniprotName
 
     // irrelevant
     //String biomarkerId

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/rbm/DeRbmAnnotation.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/rbm/DeRbmAnnotation.groovy
@@ -5,6 +5,7 @@ class DeRbmAnnotation {
     String gplId
     String antigenName
     String uniprotId
+    String uniprotName
     String geneSymbol
     String geneId
 

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/rbm/DeRbmAnnotation.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/rbm/DeRbmAnnotation.groovy
@@ -19,6 +19,7 @@ class DeRbmAnnotation {
         gplId       maxSize:  50
         antigenName maxSize:  800
         uniprotId   nullable: true, maxSize: 200
+        uniprotName nullable: true, maxSize: 200
         geneSymbol  nullable: true, maxSize: 200
         geneId      nullable: true, maxSize: 400
     }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/ProbeRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/ProbeRow.groovy
@@ -9,7 +9,7 @@ class ProbeRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     String probe
 
-    String geneSymbol
+    String uniprotName
 
     String geneId
 
@@ -20,7 +20,6 @@ class ProbeRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     @Override
     String getBioMarker() {
-        geneSymbol
+        uniprotName
     }
-
 }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/ProbeRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/ProbeRow.groovy
@@ -9,7 +9,7 @@ class ProbeRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     String probe
 
-    String uniprotName
+    String unitProtId
 
     String geneId
 
@@ -20,6 +20,6 @@ class ProbeRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     @Override
     String getBioMarker() {
-        uniprotName
+        unitProtId
     }
 }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinDataRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinDataRow.groovy
@@ -5,7 +5,7 @@ import org.transmartproject.db.dataquery.highdim.AbstractDataRow
 
 class ProteinDataRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
-    String unitProtId
+    String uniprotName
 
     String peptide
 
@@ -16,7 +16,7 @@ class ProteinDataRow extends AbstractDataRow implements BioMarkerDataRow<Object>
 
     @Override
     String getBioMarker() {
-        unitProtId
+        uniprotName
     }
 
 }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
@@ -105,7 +105,7 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
                     def firstNonNullCell = list.find()
                     new ProteinDataRow(
                             peptide:       firstNonNullCell[0].peptide,
-                            unitProtId:    firstNonNullCell[0].uniProtId,
+                            unitProtName:  firstNonNullCell[0].uniProtName,
                             assayIndexMap: assayIndexes,
                             data:          list.collect { projection.doWithResult it?.getAt(0) }
                     )

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
@@ -29,7 +29,7 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
 
     private final Set<String> dataProperties = ImmutableSet.of('intensity', 'zscore')
 
-    private final Set<String> rowProperties = ImmutableSet.of('unitProtId', 'peptide')
+    private final Set<String> rowProperties = ImmutableSet.of('uniprotName', 'peptide')
 
     @Autowired
     DataRetrievalParameterFactory standardAssayConstraintFactory
@@ -76,7 +76,7 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
                 property 'assay',       'assay'
 
                 property 'a.id',        'annotationId'
-                property 'a.uniprotId', 'uniProtId'
+                property 'a.uniprotName', 'uniProtName'
                 property 'a.peptide',   'peptide'
             }
 
@@ -105,7 +105,7 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
                     def firstNonNullCell = list.find()
                     new ProteinDataRow(
                             peptide:       firstNonNullCell[0].peptide,
-                            unitProtName:  firstNonNullCell[0].uniProtName,
+                            uniprotName:   firstNonNullCell[0].uniprotName,
                             assayIndexMap: assayIndexes,
                             data:          list.collect { projection.doWithResult it?.getAt(0) }
                     )

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
@@ -75,9 +75,9 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
             projections {
                 property 'assay',       'assay'
 
-                property 'a.id',        'annotationId'
-                property 'a.uniprotName', 'uniProtName'
-                property 'a.peptide',   'peptide'
+                property 'a.id',          'annotationId'
+                property 'a.uniprotName', 'uniprotName'
+                property 'a.peptide',     'peptide'
             }
 
             order 'a.id',     'asc'

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -74,7 +74,7 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
                 property 'assay', 'assay'
                 property 'p.id', 'annotationId'
                 property 'p.antigenName', 'antigenName'
-                property 'p.uniprotId', 'uniprotId'
+                property 'p.uniprotName', 'uniprotName'
             }
 
             order 'p.id', 'asc'
@@ -118,7 +118,7 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
                         new RbmRow(
                                 annotationId: collectedList[0].annotationId,
                                 antigenName: collectedList[0].antigenName,
-                                uniprotId: collectedList*.uniprotId.join('/'),
+                                uniprotName: collectedList*.uniprotName.join('/'),
                                 assayIndexMap: collectedList[0].assayIndexMap,
                                 data: collectedList[0].data
                         )

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -103,7 +103,7 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
                     new RbmRow(
                             annotationId: firstNonNullCell[0].annotationId,
                             antigenName: firstNonNullCell[0].antigenName,
-                            uniprotId: firstNonNullCell[0].uniprotId,
+                            uniprotName: firstNonNullCell[0].uniprotName,
                             assayIndexMap: assayIndexes,
                             data: list.collect { projection.doWithResult it?.getAt(0) }
                     )

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -101,11 +101,11 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
                 finalizeGroup: {List list ->
                     def firstNonNullCell = list.find()
                     new RbmRow(
-                            annotationId: firstNonNullCell[0].annotationId,
-                            antigenName: firstNonNullCell[0].antigenName,
-                            uniprotName: firstNonNullCell[0].uniprotName,
+                            annotationId:  firstNonNullCell[0].annotationId,
+                            antigenName:   firstNonNullCell[0].antigenName,
+                            uniprotName:   firstNonNullCell[0].uniprotName,
                             assayIndexMap: assayIndexes,
-                            data: list.collect { projection.doWithResult it?.getAt(0) }
+                            data:          list.collect { projection.doWithResult it?.getAt(0) }
                     )
                 }
         )

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -30,7 +30,7 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
 
     private final Set<String> dataProperties = ImmutableSet.of('value', 'zscore')
 
-    private final Set<String> rowProperties = ImmutableSet.of('antigenName', 'uniprotId')
+    private final Set<String> rowProperties = ImmutableSet.of('antigenName', 'uniprotName')
 
     @Autowired
     DataRetrievalParameterFactory standardAssayConstraintFactory

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmRow.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmRow.groovy
@@ -9,7 +9,7 @@ class RbmRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     Integer annotationId
 
-    String uniprotId
+    String uniprotName
 
     String antigenName
 
@@ -20,7 +20,6 @@ class RbmRow extends AbstractDataRow implements BioMarkerDataRow<Object> {
 
     @Override
     String getBioMarker() {
-        uniprotId
+        uniprotName
     }
-
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinEndToEndRetrievalTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinEndToEndRetrievalTests.groovy
@@ -33,9 +33,6 @@ class ProteinEndToEndRetrievalTests {
 
     static final Double DELTA = 0.0001
 
-    String ureaTransporterUniProtId,
-           adiponectinUnitProtId,
-           adipogenesisFactorUniProtId
     String ureaTransporterPeptide,
            adiponectinPeptide,
            adipogenesisFactorPeptide
@@ -53,18 +50,6 @@ class ProteinEndToEndRetrievalTests {
 
         projection = proteinResource.createProjection([:],
                 Projection.ZSCORE_PROJECTION)
-
-        ureaTransporterUniProtId = testData.proteins.find {
-            it.name == 'Urea transporter 2'
-        }.primaryExternalId
-
-        adiponectinUnitProtId = testData.proteins.find {
-            it.name == 'Adiponectin'
-        }.primaryExternalId
-
-        adipogenesisFactorUniProtId = testData.proteins.find {
-            it.name == 'Adipogenesis regulatory factor'
-        }.primaryExternalId
 
         ureaTransporterPeptide = testData.annotations[-1].peptide
         adiponectinPeptide = testData.annotations[-2].peptide
@@ -99,7 +84,7 @@ class ProteinEndToEndRetrievalTests {
                 contains(
                         allOf(
                                 hasProperty('label', is(ureaTransporterPeptide)),
-                                hasProperty('bioMarker', is(ureaTransporterUniProtId)),
+                                hasProperty('bioMarker', is("PVR_HUMAN3")),
                                 hasProperty('peptide', is(testData.annotations[-1].peptide))
                         ),
                         hasProperty('label', is(adiponectinPeptide)),

--- a/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinTestData.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinTestData.groovy
@@ -31,20 +31,21 @@ class ProteinTestData {
         HighDimTestData.createTestAssays(patients, -400, platform, TRIAL_NAME)
 
     List<DeProteinAnnotation> annotations = {
-        def createAnnotation = { id, proteinName, peptide ->
+        def createAnnotation = { id, proteinName, uniprotName, peptide ->
             def res = new DeProteinAnnotation(
-                    peptide:   peptide,
-                    uniprotId: biomarkerTestData.proteinBioMarkers.find { it.name == proteinName }.primaryExternalId,
-                    platform:  platform
+                    peptide:     peptide,
+                    uniprotId:   biomarkerTestData.proteinBioMarkers.find { it.name == proteinName }.primaryExternalId,
+                    uniprotName: uniprotName,
+                    platform:    platform
             )
             res.id = id
             res
         }
         [
                 // not the actual full sequences here...
-                createAnnotation(-501, 'Adipogenesis regulatory factor', 'MASKGLQDLK'),
-                createAnnotation(-502, 'Adiponectin',                    'MLLLGAVLLL'),
-                createAnnotation(-503, 'Urea transporter 2',             'MSDPHSSPLL'),
+                createAnnotation(-501, 'Adipogenesis regulatory factor', 'PVR_HUMAN1', 'MASKGLQDLK'),
+                createAnnotation(-502, 'Adiponectin',                    'PVR_HUMAN2', 'MLLLGAVLLL'),
+                createAnnotation(-503, 'Urea transporter 2',             'PVR_HUMAN3', 'MSDPHSSPLL'),
         ]
     }()
 

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmDataRetrievalTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmDataRetrievalTests.groovy
@@ -111,7 +111,7 @@ class RbmDataRetrievalTests {
                                         closeTo(testData.rbmData[-6].zscore as Double, delta)))),
                 contains(
                         allOf(
-                                hasProperty('bioMarker', equalTo('Q15848')),
+                                hasProperty('bioMarker', equalTo('PVR_HUMAN1')),
                                 hasProperty('label', equalTo('Antigene1')))))
     }
 
@@ -197,7 +197,7 @@ class RbmDataRetrievalTests {
                 hasSize(1),
                 hasItem(
                         allOf(
-                                hasProperty('bioMarker', equalTo('Q15850/Q15847')),
+                                hasProperty('bioMarker', equalTo('PVR_HUMAN4/PVR_HUMAN3')),
                                 hasProperty('label', equalTo('Antigene3')),
                                 contains(
                                         closeTo(testData.rbmData[-1].zscore as Double, delta),

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmTestData.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmTestData.groovy
@@ -32,11 +32,12 @@ class RbmTestData {
         HighDimTestData.createTestAssays(patients, -400, platform, TRIAL_NAME)
 
     List<DeRbmAnnotation> annotations = {
-        def createAnnotation = { id, antigene, uniprotId, geneSymbol, geneId ->
+        def createAnnotation = { id, antigene, uniprotId, uniprotName, geneSymbol, geneId ->
             def res = new DeRbmAnnotation(
                     gplId: platform.id,
                     antigenName: antigene,
                     uniprotId: uniprotId,
+                    uniprotName: uniprotName,
                     geneSymbol: geneSymbol,
                     geneId: geneId
             )
@@ -45,13 +46,13 @@ class RbmTestData {
         }
         [
                 //Adiponectin
-                createAnnotation(-501, 'Antigene1', 'Q15848', 'AURKA', -601),
+                createAnnotation(-501, 'Antigene1', 'Q15848', 'PVR_HUMAN1', 'AURKA', -601),
                 //Urea transporter 2
-                createAnnotation(-502, 'Antigene2', 'Q15849', 'SLC14A2', -602),
+                createAnnotation(-502, 'Antigene2', 'Q15849', 'PVR_HUMAN2', 'SLC14A2', -602),
                 //Adipogenesis regulatory factor
-                createAnnotation(-503, 'Antigene3', 'Q15847', 'ADIRF', -603),
+                createAnnotation(-503, 'Antigene3', 'Q15847', 'PVR_HUMAN3', 'ADIRF', -603),
 
-                createAnnotation(-504, 'Antigene3', 'Q15850', 'EMBL', -604),
+                createAnnotation(-504, 'Antigene3', 'Q15850', 'PVR_HUMAN4', 'EMBL', -604),
         ]
     }()
 


### PR DESCRIPTION
Please take a careful look at this. I believe it is correct.

You'll notice some values for uniprotName being hard coded in the test data. This is intentional as these values are inserted during ETL.

I've also updated the [wiki page](https://wiki.thehyve.nl/display/SAN/Database+setup+for+new+datatypes) to reflect the new schema. In addition to this these are the queries I ran on CI to add the columns:

```
alter table deapp.de_protein_annotation add (uniprot_name VARCHAR2(200 CHAR));
comment on column deapp.de_protein_annotation.uniprot_name is 'UniProt name for this analyte.';
```

And for RBM:

```
alter table deapp.de_rbm_annotation add (uniprot_name VARCHAR2(200 CHAR));
comment on column deapp.de_rbm_annotation.uniprot_id is 'UniProtID for this analyte. Refers to the uniprot database (www.uniprot.org), which is loaded as a dictionary in the biomarker table.';
```
