### PR TITLE
Create tests for the AllDataProjection and HighDimensionDataTypeResource...

### DIFF
--- a/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionGenericTests.groovy
@@ -1,0 +1,88 @@
+package org.transmartproject.db.dataquery.highdim
+
+import grails.util.Holders
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
+import org.transmartproject.core.dataquery.highdim.HighDimensionResource
+import org.transmartproject.core.dataquery.highdim.projections.AllDataProjection
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.acgh.AcghTestData
+import org.transmartproject.db.dataquery.highdim.metabolite.MetaboliteTestData
+import org.transmartproject.db.dataquery.highdim.mirna.MirnaTestData
+import org.transmartproject.db.dataquery.highdim.mrna.MrnaTestData
+import org.transmartproject.db.dataquery.highdim.protein.ProteinTestData
+import org.transmartproject.db.dataquery.highdim.rbm.RbmTestData
+import org.transmartproject.db.dataquery.highdim.rnaseq.RnaSeqTestData
+import org.transmartproject.db.dataquery.highdim.rnaseqcog.RnaSeqCogTestData
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+/**
+ * Created by jan on 2/4/14.
+ */
+
+/*
+ * This should be done with parametrized tests, but that doesn't work in grails 2.2, it needs 2.3.
+ * For now this test is made abstract and extended for the specific HD data types.
+ *
+ * FIXME when the grails version is updated
+ */
+//@RunWith(value = Parameterized)
+abstract class HighDimensionGenericTests {
+
+    HighDimensionDataTypeResource type
+    def testData
+
+    HighDimensionGenericTests(HighDimensionDataTypeResource type, Class testData) {
+        this.type = type
+        this.testData = testData.newInstance()
+    }
+
+    /**
+     * A convenience constructor for the workaround for parameterized tests
+     */
+    HighDimensionGenericTests(String typeName, Class testData) {
+        HighDimensionResource hdrs = Holders.grailsApplication.mainContext.getBean('highDimensionResourceService')
+        this.type = hdrs.getSubResourceForType(typeName)
+        this.testData = testData.newInstance()
+    }
+
+    @Before
+    void setUp() {
+        assertThat type, is(notNullValue())
+        assertThat testData, is(notNullValue())
+        testData.saveAll()
+    }
+
+    @Test
+    void testDescription() {
+        assertThat type.dataTypeDescription, instanceOf(String)
+    }
+
+    @Test
+    void testGenericProjection() {
+        AllDataProjection genericProjection = type.createProjection(Projection.ALL_DATA_PROJECTION)
+
+        def result = type.retrieveData([], [], genericProjection)
+        def indicesList = result.indicesList
+        def firstrow = result.iterator().next()
+
+        assertThat firstrow, is(notNullValue())
+        genericProjection.rowProperties.each {
+            assertThat firstrow, hasProperty(it)
+        }
+
+        def data = firstrow[indicesList[0]]
+
+        assertThat data, is(notNullValue())
+        assertThat data, is(instanceOf(Map))
+        genericProjection.dataProperties.each {
+            assertThat data, hasKey(it)
+        }
+    }
+
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/HighDimensionGenericTests.groovy
@@ -35,19 +35,25 @@ import static org.hamcrest.Matchers.*
 abstract class HighDimensionGenericTests {
 
     HighDimensionDataTypeResource type
+    List<String> dataProperties
+    List<String> rowProperties
     def testData
 
-    HighDimensionGenericTests(HighDimensionDataTypeResource type, Class testData) {
+    HighDimensionGenericTests(HighDimensionDataTypeResource type, List<String> dataProperties, List<String> rowProperties, Class testData) {
         this.type = type
+        this.dataProperties = dataProperties
+        this.rowProperties = rowProperties
         this.testData = testData.newInstance()
     }
 
     /**
      * A convenience constructor for the workaround for parameterized tests
      */
-    HighDimensionGenericTests(String typeName, Class testData) {
+    HighDimensionGenericTests(String typeName, List<String> dataProperties, List<String> rowProperties, Class testData) {
         HighDimensionResource hdrs = Holders.grailsApplication.mainContext.getBean('highDimensionResourceService')
         this.type = hdrs.getSubResourceForType(typeName)
+        this.dataProperties = dataProperties
+        this.rowProperties = rowProperties
         this.testData = testData.newInstance()
     }
 
@@ -64,7 +70,7 @@ abstract class HighDimensionGenericTests {
     }
 
     @Test
-    void testGenericProjection() {
+    void testAllDataProjection() {
         AllDataProjection genericProjection = type.createProjection(Projection.ALL_DATA_PROJECTION)
 
         def result = type.retrieveData([], [], genericProjection)
@@ -72,6 +78,9 @@ abstract class HighDimensionGenericTests {
         def firstrow = result.iterator().next()
 
         assertThat firstrow, is(notNullValue())
+        rowProperties.each {
+            assertThat genericProjection.rowProperties, hasItem(it)
+        }
         genericProjection.rowProperties.each {
             assertThat firstrow, hasProperty(it)
         }
@@ -80,6 +89,9 @@ abstract class HighDimensionGenericTests {
 
         assertThat data, is(notNullValue())
         assertThat data, is(instanceOf(Map))
+        dataProperties.each {
+            assertThat genericProjection.dataProperties, hasItem(it)
+        }
         genericProjection.dataProperties.each {
             assertThat data, hasKey(it)
         }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class MetaboliteGenericTests extends HighDimensionGenericTests {
 
     MetaboliteGenericTests() {
-        super('metabolite', MetaboliteTestData)
+        super('metabolite',
+                ['rawIntensity', 'logIntensity', 'zscore'],
+                ['hmdbId', 'biochemicalName'],
+                MetaboliteTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.metabolite
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class MetaboliteGenericTests extends HighDimensionGenericTests {
+
+    MetaboliteGenericTests() {
+        super('metabolite', MetaboliteTestData)
+    }
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.mirna
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class MirnaGenericTests extends HighDimensionGenericTests {
+
+    MirnaGenericTests() {
+        super('mirna', MirnaTestData)
+    }
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class MirnaGenericTests extends HighDimensionGenericTests {
 
     MirnaGenericTests() {
-        super('mirna', MirnaTestData)
+        super('mirna',
+                ['rawIntensity', 'logIntensity', 'zscore'],
+                ['probeId', 'mirnaId'],
+                MirnaTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/mrna/MrnaGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/mrna/MrnaGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class MrnaGenericTests extends HighDimensionGenericTests {
 
     MrnaGenericTests() {
-        super('mrna', MrnaTestData)
+        super('mrna',
+                ['trialName', 'rawIntensity', 'logIntensity', 'zscore'],
+                ['probe', 'geneId', 'geneSymbol'],
+                MrnaTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/mrna/MrnaGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/mrna/MrnaGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.mrna
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class MrnaGenericTests extends HighDimensionGenericTests {
+
+    MrnaGenericTests() {
+        super('mrna', MrnaTestData)
+    }
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.protein
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class ProteinGenericTests extends HighDimensionGenericTests {
+
+    ProteinGenericTests() {
+        super('protein', ProteinTestData)
+    }
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/protein/ProteinGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class ProteinGenericTests extends HighDimensionGenericTests {
 
     ProteinGenericTests() {
-        super('protein', ProteinTestData)
+        super('protein',
+                ['intensity', 'zscore'],
+                ['uniprotName', 'peptide'],
+                ProteinTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.rbm
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class RbmGenericTests extends HighDimensionGenericTests {
+
+    RbmGenericTests() {
+        super('rbm', RbmTestData)
+    }
+}

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rbm/RbmGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class RbmGenericTests extends HighDimensionGenericTests {
 
     RbmGenericTests() {
-        super('rbm', RbmTestData)
+        super('rbm',
+                ['value', 'zscore'],
+                ['antigenName', 'uniprotName'],
+                RbmTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogGenericTests.groovy
@@ -8,6 +8,9 @@ import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
 class RnaSeqCogGenericTests extends HighDimensionGenericTests {
 
     RnaSeqCogGenericTests() {
-        super('rnaseq_cog', RnaSeqCogTestData)
+        super('rnaseq_cog',
+                ['rawIntensity', 'zscore'],
+                ['annotationId', 'geneSymbol', 'geneId'],
+                RnaSeqCogTestData)
     }
 }

--- a/test/integration/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogGenericTests.groovy
+++ b/test/integration/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogGenericTests.groovy
@@ -1,0 +1,13 @@
+package org.transmartproject.db.dataquery.highdim.rnaseqcog
+
+import org.transmartproject.db.dataquery.highdim.HighDimensionGenericTests
+
+/**
+ * Created by jan on 2/5/14.
+ */
+class RnaSeqCogGenericTests extends HighDimensionGenericTests {
+
+    RnaSeqCogGenericTests() {
+        super('rnaseq_cog', RnaSeqCogTestData)
+    }
+}


### PR DESCRIPTION
....dataTypeDescription

This change needs to test a number of features for all existing HD data types. The best way to do that would be parametrized tests, but grails 2.4 does not support that. I have now implemented this with an abstract class that is extended for every data type. 

The rnaseq (not _cog) datatype uses such a different structure in its data query that it needs substantial changes before it passes this test. Since it was created by Wim van der Linden and not used in our current branch I have skipped it for now. 
