### PR TITLE
Make tags associated with tag types appear first.

### DIFF
--- a/grails-app/domain/org/transmartproject/db/ontology/I2b2TagOption.groovy
+++ b/grails-app/domain/org/transmartproject/db/ontology/I2b2TagOption.groovy
@@ -4,11 +4,14 @@ class I2b2TagOption {
 
     String value
 
+    static belongsTo = [type: I2b2TagType]
+
     static  mapping = {
         table           name: 'i2b2_tag_options', schema: 'i2b2metadata'
         version         false
 
         id              column: 'tag_option_id', generator: 'sequence'
+        type            column: 'tag_type_id'
     }
 
 }

--- a/grails-app/services/org/transmartproject/db/ontology/OntologyTermTagsResourceService.groovy
+++ b/grails-app/services/org/transmartproject/db/ontology/OntologyTermTagsResourceService.groovy
@@ -1,5 +1,6 @@
 package org.transmartproject.db.ontology
 
+import org.hibernate.criterion.CriteriaSpecification
 import org.transmartproject.core.ontology.OntologyTerm
 import org.transmartproject.core.ontology.OntologyTermTag
 import org.transmartproject.core.ontology.OntologyTermTagsResource
@@ -12,7 +13,15 @@ class OntologyTermTagsResourceService implements OntologyTermTagsResource {
             return [:]
         }
 
-        def orderedTags = I2b2Tag.createCriteria().list {
+        /**
+         * The query for tags is split into two separate queries, to make sure
+         * that tags associated with tag types (through the 'option' field)
+         * appear first.
+         * This could be done in a single query once 'NULLS LAST' is supported in Grails.
+         */
+        def orderedTags = I2b2Tag.createCriteria().listDistinct {
+            createAlias('option', 'o', CriteriaSpecification.INNER_JOIN)
+            createAlias('o.type', 't', CriteriaSpecification.INNER_JOIN)
             or {
                 ontologyTerms.each { OntologyTerm term ->
                     if (includeDescendantsTags) {
@@ -23,8 +32,24 @@ class OntologyTermTagsResourceService implements OntologyTermTagsResource {
                 }
             }
             order 'ontologyTermFullName'
-            order 'position'
+            order 't.index'
         }
+        orderedTags.addAll(
+            I2b2Tag.createCriteria().list {
+                or {
+                    ontologyTerms.each { OntologyTerm term ->
+                        if (includeDescendantsTags) {
+                            like 'ontologyTermFullName', (term.fullName.asLikeLiteral() + '%')
+                        } else {
+                            eq 'ontologyTermFullName', term.fullName
+                        }
+                    }
+                }
+                isNull 'option'
+                order 'ontologyTermFullName'
+                order 'position'
+            }
+        )
 
         def terms = I2b2.findAllByFullNameInList((orderedTags*.ontologyTermFullName).unique())
         def termsMap = terms.collectEntries { [it.fullName, it] }

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/ontology/ConceptTestData.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/ontology/ConceptTestData.groovy
@@ -206,15 +206,18 @@ class ConceptTestData {
             'T-shirt size': ['XS', 'S', 'M', 'L', 'XL'],
         ]
         int index = startIndex
-        tagTypes.collect { type, options -> new I2b2TagType(
+        tagTypes.collect { type, options ->
+            def tagType = new I2b2TagType(
                 nodeType: 'STUDY',
                 valueType: 'NON_ANALYZED_STRING',
                 shownIfEmpty: true,
                 index: index++,
                 solrFieldName: type.toLowerCase().replaceAll(' ', '_'),
                 tagType: type,
-                options: options.collect { option -> new I2b2TagOption(value: option) },
-        )}
+            )
+            options.each { option -> tagType.addToOptions(new I2b2TagOption(value: option)) }
+            tagType
+        }
     }
 
     static List<I2b2Tag> createI2b2Tags(List<I2b2> list, int number = 2, List<I2b2TagType> tagTypes = []) {

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/ontology/OntologyTermTagsResourceServiceTests.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/ontology/OntologyTermTagsResourceServiceTests.groovy
@@ -35,20 +35,20 @@ class OntologyTermTagsResourceServiceTests {
                 hasProperty('key', equalTo(key)),
                 contains(
                     allOf(
+                        hasProperty('name', equalTo('Continent')),
+                        hasProperty('description', equalTo('Antarctica')),
+                    ),
+                    allOf(
+                        hasProperty('name', equalTo('T-shirt size')),
+                        hasProperty('description', equalTo('M')),
+                    ),
+                    allOf(
                         hasProperty('name', equalTo('1 name 2')),
                         hasProperty('description', equalTo('1 description 2')),
                     ),
                     allOf(
                         hasProperty('name', equalTo('1 name 1')),
                         hasProperty('description', equalTo('1 description 1')),
-                    ),
-                    allOf(
-                            hasProperty('name', equalTo('Continent')),
-                            hasProperty('description', equalTo('Antarctica')),
-                    ),
-                    allOf(
-                            hasProperty('name', equalTo('T-shirt size')),
-                            hasProperty('description', equalTo('M')),
                     ),
                 ))
     }
@@ -67,6 +67,14 @@ class OntologyTermTagsResourceServiceTests {
                         hasProperty('key', equalTo(key1)),
                         contains(
                                 allOf(
+                                        hasProperty('name', equalTo('Continent')),
+                                        hasProperty('description', equalTo('Antarctica')),
+                                ),
+                                allOf(
+                                        hasProperty('name', equalTo('T-shirt size')),
+                                        hasProperty('description', equalTo('M')),
+                                ),
+                                allOf(
                                         hasProperty('name', equalTo('1 name 2')),
                                         hasProperty('description', equalTo('1 description 2')),
                                 ),
@@ -74,6 +82,10 @@ class OntologyTermTagsResourceServiceTests {
                                         hasProperty('name', equalTo('1 name 1')),
                                         hasProperty('description', equalTo('1 description 1')),
                                 ),
+                        )),
+                hasEntry(
+                        hasProperty('key', equalTo(key2)),
+                        contains(
                                 allOf(
                                         hasProperty('name', equalTo('Continent')),
                                         hasProperty('description', equalTo('Antarctica')),
@@ -82,10 +94,6 @@ class OntologyTermTagsResourceServiceTests {
                                         hasProperty('name', equalTo('T-shirt size')),
                                         hasProperty('description', equalTo('M')),
                                 ),
-                        )),
-                hasEntry(
-                        hasProperty('key', equalTo(key2)),
-                        contains(
                                 allOf(
                                         hasProperty('name', equalTo('3 name 2')),
                                         hasProperty('description', equalTo('3 description 2')),
@@ -93,14 +101,6 @@ class OntologyTermTagsResourceServiceTests {
                                 allOf(
                                         hasProperty('name', equalTo('3 name 1')),
                                         hasProperty('description', equalTo('3 description 1')),
-                                ),
-                                allOf(
-                                        hasProperty('name', equalTo('Continent')),
-                                        hasProperty('description', equalTo('Antarctica')),
-                                ),
-                                allOf(
-                                        hasProperty('name', equalTo('T-shirt size')),
-                                        hasProperty('description', equalTo('M')),
                                 ),
                         )),
         )
@@ -118,6 +118,14 @@ class OntologyTermTagsResourceServiceTests {
                     hasProperty('key', equalTo(key)),
                     contains(
                             allOf(
+                                    hasProperty('name', equalTo('Continent')),
+                                    hasProperty('description', equalTo('Antarctica')),
+                            ),
+                            allOf(
+                                    hasProperty('name', equalTo('T-shirt size')),
+                                    hasProperty('description', equalTo('M')),
+                            ),
+                            allOf(
                                     hasProperty('name', equalTo('1 name 2')),
                                     hasProperty('description', equalTo('1 description 2')),
                             ),
@@ -125,6 +133,10 @@ class OntologyTermTagsResourceServiceTests {
                                     hasProperty('name', equalTo('1 name 1')),
                                     hasProperty('description', equalTo('1 description 1')),
                             ),
+                    )),
+                hasEntry(
+                    hasProperty('key', equalTo("${key}bar\\".toString())),
+                    contains(
                             allOf(
                                     hasProperty('name', equalTo('Continent')),
                                     hasProperty('description', equalTo('Antarctica')),
@@ -133,10 +145,6 @@ class OntologyTermTagsResourceServiceTests {
                                     hasProperty('name', equalTo('T-shirt size')),
                                     hasProperty('description', equalTo('M')),
                             ),
-                    )),
-                hasEntry(
-                    hasProperty('key', equalTo("${key}bar\\".toString())),
-                    contains(
                             allOf(
                                     hasProperty('name', equalTo('2 name 2')),
                                     hasProperty('description', equalTo('2 description 2')),
@@ -144,14 +152,6 @@ class OntologyTermTagsResourceServiceTests {
                             allOf(
                                     hasProperty('name', equalTo('2 name 1')),
                                     hasProperty('description', equalTo('2 description 1')),
-                            ),
-                            allOf(
-                                    hasProperty('name', equalTo('Continent')),
-                                    hasProperty('description', equalTo('Antarctica')),
-                            ),
-                            allOf(
-                                    hasProperty('name', equalTo('T-shirt size')),
-                                    hasProperty('description', equalTo('M')),
                             ),
                     )),
         )


### PR DESCRIPTION
Change order of tags such that tags associated with
tag type option appear first and are sorted by the
tag type index.
